### PR TITLE
Fixed leaflet controls placement on narrow screens

### DIFF
--- a/frontend/src/features/map/map.css
+++ b/frontend/src/features/map/map.css
@@ -6,6 +6,8 @@
 
 @media only screen and (max-width: 1024px) {
   .map { width: 100vw; }
+
+  .leaflet-control-container>div:first-child { top: 50px; }
 }
 
 @media only screen and (min-width: 1024px) {


### PR DESCRIPTION
On narrow screens (like phones), the menu is hidden and an icon is added to pull it out. This gets placed on top of the leaflet zoom controls. This PR adds conditional CSS to move the zoom controls down on small screens so that they don't interfere with the menu button.