### PR TITLE
Full width tables in the leaderboard

### DIFF
--- a/frontend/src/features/leaderboard/leaderboard.css
+++ b/frontend/src/features/leaderboard/leaderboard.css
@@ -1,0 +1,3 @@
+.full-width {
+    width: 100%;
+}

--- a/frontend/src/features/leaderboard/leaderboard.pug
+++ b/frontend/src/features/leaderboard/leaderboard.pug
@@ -3,7 +3,7 @@ p Tweet more to rise up the leaderboard! Make sure you enable geolocation to get
 
 p To encourage more wildlife into your area, read more about different #[a(href="/species") species] and how to improve their habitats.
 
-table.mdl-data-table.mdl-js-data-table.mdl-shadow--2dp
+table.mdl-data-table.mdl-js-data-table.mdl-shadow--2dp.full-width
   thead
     tr
       th.mdl-data-table__cell--non-numeric User


### PR DESCRIPTION
How do y'all feel about this?

Replacing:
<img width="1900" alt="screen shot 2017-05-05 at 00 54 29" src="https://cloud.githubusercontent.com/assets/679355/25729502/9be0627a-312d-11e7-88d3-85c4aa189ac2.png">

With:
<img width="1910" alt="screen shot 2017-05-05 at 00 53 06" src="https://cloud.githubusercontent.com/assets/679355/25729507/a4c4f39c-312d-11e7-9f39-50a9a2c14849.png">


Appears better to me on desktop, not tried mobile.

#devops